### PR TITLE
Migration to Minkowski Engine v0.5 and Open3D v0.15 for demo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,17 @@ The entire network depends on pretrained [FCGF models](https://github.com/chrisc
 You may download preprocessed data and train via these commands:
 ```shell
 ./scripts/download_3dmatch.sh /path/to/3dmatch
-export THREED_MATCH_DIR=/path/to/3dmatch; FCGF_WEIGHTS=/path/to/fcgf_3dmatch.pth ./scripts/train_3dmatch.sh
+export THREED_MATCH_DIR=/path/to/3dmatch
+export FCGF_WEIGHTS=/path/to/fcgf_3dmatch.pth
+./scripts/train_3dmatch.sh
 ```
 
 ### KITTI
 Follow the instruction on [KITTI Odometry website](http://www.cvlibs.net/datasets/kitti/eval_odometry.php) to download the KITTI odometry train set. Then train with
 ```shell
-export KITTI_PATH=/path/to/kitti; FCGF_WEIGHTS=/path/to/fcgf_kitti.pth ./scripts/train_kitti.sh
+export KITTI_PATH=/path/to/kitti
+export FCGF_WEIGHTS=/path/to/fcgf_kitti.pth
+./scripts/train_kitti.sh
 ```
 
 ## Testing

--- a/core/deep_global_registration.py
+++ b/core/deep_global_registration.py
@@ -160,7 +160,7 @@ class DeepGlobalRegistration:
     '''
     Step 1: extract fast and accurate FCGF feature per point
     '''
-    sinput = ME.SparseTensor(feats, coords=coords).to(self.device)
+    sinput = ME.SparseTensor(feats, coordinates=coords, device=self.device)
 
     return self.fcgf_model(sinput).F
 
@@ -207,7 +207,7 @@ class DeepGlobalRegistration:
     '''
     Step 4: predict inlier likelihood
     '''
-    sinput = ME.SparseTensor(inlier_feats, coords=coords).to(self.device)
+    sinput = ME.SparseTensor(inlier_feats, coordinates=coords, device=self.device)
     soutput = self.inlier_model(sinput)
 
     return soutput.F

--- a/core/deep_global_registration.py
+++ b/core/deep_global_registration.py
@@ -145,7 +145,7 @@ class DeepGlobalRegistration:
 
     # Voxelization:
     # Maintain double type for xyz to improve numerical accuracy in quantization
-    sel = ME.utils.sparse_quantize(xyz / self.voxel_size, return_index=True)
+    _coords, sel = ME.utils.sparse_quantize(xyz / self.voxel_size, return_index=True)
     npts = len(sel)
 
     xyz = torch.from_numpy(xyz[sel])

--- a/core/deep_global_registration.py
+++ b/core/deep_global_registration.py
@@ -311,9 +311,9 @@ class DeepGlobalRegistration:
       print(f'=> Safeguard takes {safeguard_time:.2} s')
 
     if self.use_icp:
-      T = o3d.registration.registration_icp(
+      T = o3d.pipelines.registration.registration_icp(
           make_open3d_point_cloud(xyz0),
           make_open3d_point_cloud(xyz1), self.voxel_size * 2, T,
-          o3d.registration.TransformationEstimationPointToPoint()).transformation
+          o3d.pipelines.registration.TransformationEstimationPointToPoint()).transformation
 
     return T

--- a/model/pyramidnet.py
+++ b/model/pyramidnet.py
@@ -15,7 +15,7 @@ from model.residual_block import get_block, conv, conv_tr, conv_norm_non
 class PyramidModule(ME.MinkowskiNetwork):
   NONLINEARITY = 'ELU'
   NORM_TYPE = 'BN'
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   def __init__(self,
                inc,
@@ -55,7 +55,7 @@ class PyramidModule(ME.MinkowskiNetwork):
             kernel_size=3,
             stride=2,
             dilation=1,
-            has_bias=False,
+            bias=False,
             region_type=self.REGION_TYPE,
             dimension=dimension),
         get_norm(
@@ -93,7 +93,7 @@ class PyramidNet(ME.MinkowskiNetwork):
   DEPTHS = [1, 1, 1, 1]
   # None        b1, b2, b3, btr3, btr2
   #               1  2  3 -3 -2 -1
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -157,8 +157,8 @@ class PyramidNet(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 

--- a/model/pyramidnet.py
+++ b/model/pyramidnet.py
@@ -15,7 +15,7 @@ from model.residual_block import get_block, conv, conv_tr, conv_norm_non
 class PyramidModule(ME.MinkowskiNetwork):
   NONLINEARITY = 'ELU'
   NORM_TYPE = 'BN'
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   def __init__(self,
                inc,
@@ -93,7 +93,7 @@ class PyramidNet(ME.MinkowskiNetwork):
   DEPTHS = [1, 1, 1, 1]
   # None        b1, b2, b3, btr3, btr2
   #               1  2  3 -3 -2 -1
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords

--- a/model/residual_block.py
+++ b/model/residual_block.py
@@ -22,7 +22,7 @@ def conv(in_channels,
          dimension=3):
   if not isinstance(region_type, ME.RegionType):
     if region_type == 0:
-      region_type = ME.RegionType.HYPERCUBE
+      region_type = ME.RegionType.HYPER_CUBE
     elif region_type == 1:
       region_type = ME.RegionType.HYPERCROSS
     else:
@@ -50,7 +50,7 @@ def conv_tr(in_channels,
             stride=1,
             dilation=1,
             has_bias=False,
-            region_type=ME.RegionType.HYPERCUBE,
+            region_type=ME.RegionType.HYPER_CUBE,
             dimension=-1):
   assert dimension > 0, 'Dimension must be a positive integer'
   kernel_generator = ME.KernelGenerator(
@@ -174,7 +174,7 @@ def conv_norm_non(inc,
                   stride,
                   dimension,
                   bn_momentum=0.05,
-                  region_type=ME.RegionType.HYPERCUBE,
+                  region_type=ME.RegionType.HYPER_CUBE,
                   norm_type='BN',
                   nonlinearity='ELU'):
   return nn.Sequential(

--- a/model/residual_block.py
+++ b/model/residual_block.py
@@ -75,7 +75,7 @@ def conv_tr(in_channels,
       kernel_size=kernel_size,
       stride=stride,
       dilation=dilation,
-      has_bias=has_bias,
+      bias=has_bias,
       kernel_generator=kernel_generator,
       dimension=dimension)
 

--- a/model/residual_block.py
+++ b/model/residual_block.py
@@ -17,14 +17,14 @@ def conv(in_channels,
          kernel_size=3,
          stride=1,
          dilation=1,
-         has_bias=False,
+         bias=False,
          region_type=0,
          dimension=3):
   if not isinstance(region_type, ME.RegionType):
     if region_type == 0:
-      region_type = ME.RegionType.HYPERCUBE
+      region_type = ME.RegionType.HYPER_CUBE
     elif region_type == 1:
-      region_type = ME.RegionType.HYPERCROSS
+      region_type = ME.RegionType.HYPER_CROSS
     else:
       raise ValueError('Unsupported region type')
 
@@ -49,8 +49,8 @@ def conv_tr(in_channels,
             kernel_size,
             stride=1,
             dilation=1,
-            has_bias=False,
-            region_type=ME.RegionType.HYPERCUBE,
+            bias=False,
+            region_type=ME.RegionType.HYPER_CUBE,
             dimension=-1):
   assert dimension > 0, 'Dimension must be a positive integer'
   kernel_generator = ME.KernelGenerator(
@@ -75,7 +75,7 @@ def conv_tr(in_channels,
       kernel_size=kernel_size,
       stride=stride,
       dilation=dilation,
-      has_bias=has_bias,
+      bias=bias,
       kernel_generator=kernel_generator,
       dimension=dimension)
 
@@ -174,7 +174,7 @@ def conv_norm_non(inc,
                   stride,
                   dimension,
                   bn_momentum=0.05,
-                  region_type=ME.RegionType.HYPERCUBE,
+                  region_type=ME.RegionType.HYPER_CUBE,
                   norm_type='BN',
                   nonlinearity='ELU'):
   return nn.Sequential(
@@ -184,7 +184,7 @@ def conv_norm_non(inc,
           kernel_size=kernel_size,
           stride=stride,
           dilation=1,
-          has_bias=False,
+          bias=False,
           region_type=region_type,
           dimension=dimension),
       get_norm(norm_type, outc, bn_momentum=bn_momentum, dimension=dimension),

--- a/model/resunet.py
+++ b/model/resunet.py
@@ -643,8 +643,8 @@ class ResUNet2(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 

--- a/model/resunet.py
+++ b/model/resunet.py
@@ -18,7 +18,7 @@ class ResUNet(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128]
   TR_CHANNELS = [None, 32, 64, 64]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -43,7 +43,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -61,7 +61,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
 
@@ -79,7 +79,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
 
@@ -97,7 +97,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -116,7 +116,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -135,7 +135,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     # self.block1_tr = BasicBlockBN(TR_CHANNELS[1], TR_CHANNELS[1], bn_momentum=bn_momentum, D=D)
@@ -146,7 +146,7 @@ class ResUNet(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -185,8 +185,8 @@ class ResUNet(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -202,7 +202,7 @@ class ResUNetBNF(ResUNet):
 
 
 class ResUNetBNFX(ResUNetBNF):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetSP(ME.MinkowskiNetwork):
@@ -213,7 +213,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
   # None        b1, b2, b3, btr3, btr2
   #               1  2  3 -3 -2 -1
   DEPTHS = [None, 1, 1, 1, 1, 1, None]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -238,7 +238,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
@@ -260,7 +260,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
 
@@ -281,7 +281,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
 
@@ -302,7 +302,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -324,7 +324,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm2_tr = get_norm(
@@ -346,7 +346,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
 
@@ -358,7 +358,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -402,14 +402,14 @@ class ResUNetSP(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
 
 class ResUNetBNSPC(ResUNetSP):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetINBNSPC(ResUNetBNSPC):
@@ -421,7 +421,7 @@ class ResUNet2(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128, 256]
   TR_CHANNELS = [None, 32, 64, 64, 128]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -445,7 +445,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
@@ -464,7 +464,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -483,7 +483,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -502,7 +502,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm4 = get_norm(NORM_TYPE, CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -521,7 +521,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm4_tr = get_norm(
@@ -541,7 +541,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm3_tr = get_norm(
@@ -561,7 +561,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm2_tr = get_norm(
@@ -581,7 +581,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     # self.block1_tr = BasicBlockBN(TR_CHANNELS[1], TR_CHANNELS[1], bn_momentum=bn_momentum, D=D)
@@ -592,7 +592,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -643,8 +643,8 @@ class ResUNet2(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -666,7 +666,7 @@ class ResUNetBN2C(ResUNet2):
 
 
 class ResUNetBN2CX(ResUNetBN2C):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetBN2D(ResUNet2):
@@ -688,7 +688,7 @@ class ResUNetBN2F(ResUNet2):
 
 
 class ResUNetBN2FX(ResUNetBN2F):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNet2v2(ME.MinkowskiNetwork):
@@ -699,7 +699,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
   # None        b1, b2, b3, b4, btr4, btr3, btr2
   #               1  2  3  4,-4,-3,-2,-1
   DEPTHS = [None, 1, 1, 1, 1, 1, 1, 1, None]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -724,7 +724,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -743,7 +743,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
 
@@ -762,7 +762,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
 
@@ -781,7 +781,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4 = get_norm(NORM_TYPE, CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
 
@@ -800,7 +800,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -820,7 +820,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -840,7 +840,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -860,7 +860,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     # self.block1_tr = BasicBlockBN(TR_CHANNELS[1], TR_CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
@@ -871,7 +871,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
     self.weight_initialization()
 
@@ -932,8 +932,8 @@ class ResUNet2v2(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -977,7 +977,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128, 256]
   TR_CHANNELS = [None, 32, 64, 64, 128]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -1001,8 +1001,8 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
-        region_type=ME.RegionType.HYPERCUBE,
+        bias=False,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -1021,7 +1021,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -1041,7 +1041,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -1061,8 +1061,8 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=1,
         dilation=1,
-        has_bias=False,
-        region_type=ME.RegionType.HYPERCUBE,
+        bias=False,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
     self.norm4 = get_norm(NORM_TYPE, CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
 
@@ -1071,7 +1071,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         CHANNELS[4],
         CHANNELS[4],
         bn_momentum=bn_momentum,
-        region_type=ME.RegionType.HYPERCUBE,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
 
     self.conv4_tr = conv_tr(
@@ -1080,8 +1080,8 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
-        region_type=ME.RegionType.HYPERCUBE,
+        bias=False,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
     self.norm4_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -1100,7 +1100,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm3_tr = get_norm(
@@ -1120,7 +1120,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         region_type=REGION_TYPE,
         dimension=D)
     self.norm2_tr = get_norm(
@@ -1140,7 +1140,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     # self.block1_tr = BasicBlockBN(TR_CHANNELS[1], TR_CHANNELS[1], bn_momentum=bn_momentum, D=D)
@@ -1151,7 +1151,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -1205,8 +1205,8 @@ class ResUNet2SP(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / (torch.norm(out.F, p=2, dim=1, keepdim=True) + 1e-8),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -1218,4 +1218,4 @@ class ResUNetBN2SPC(ResUNet2SP):
 
 
 class ResUNetBN2SPCX(ResUNetBN2SPC):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS

--- a/model/resunet.py
+++ b/model/resunet.py
@@ -592,7 +592,7 @@ class ResUNet2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):

--- a/model/resunet.py
+++ b/model/resunet.py
@@ -18,7 +18,7 @@ class ResUNet(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128]
   TR_CHANNELS = [None, 32, 64, 64]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -202,7 +202,7 @@ class ResUNetBNF(ResUNet):
 
 
 class ResUNetBNFX(ResUNetBNF):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetSP(ME.MinkowskiNetwork):
@@ -213,7 +213,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
   # None        b1, b2, b3, btr3, btr2
   #               1  2  3 -3 -2 -1
   DEPTHS = [None, 1, 1, 1, 1, 1, None]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -409,7 +409,7 @@ class ResUNetSP(ME.MinkowskiNetwork):
 
 
 class ResUNetBNSPC(ResUNetSP):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetINBNSPC(ResUNetBNSPC):
@@ -421,7 +421,7 @@ class ResUNet2(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128, 256]
   TR_CHANNELS = [None, 32, 64, 64, 128]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -666,7 +666,7 @@ class ResUNetBN2C(ResUNet2):
 
 
 class ResUNetBN2CX(ResUNetBN2C):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNetBN2D(ResUNet2):
@@ -688,7 +688,7 @@ class ResUNetBN2F(ResUNet2):
 
 
 class ResUNetBN2FX(ResUNetBN2F):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS
 
 
 class ResUNet2v2(ME.MinkowskiNetwork):
@@ -699,7 +699,7 @@ class ResUNet2v2(ME.MinkowskiNetwork):
   # None        b1, b2, b3, b4, btr4, btr3, btr2
   #               1  2  3  4,-4,-3,-2,-1
   DEPTHS = [None, 1, 1, 1, 1, 1, 1, 1, None]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -977,7 +977,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
   BLOCK_NORM_TYPE = 'BN'
   CHANNELS = [None, 32, 64, 128, 256]
   TR_CHANNELS = [None, 32, 64, 64, 128]
-  REGION_TYPE = ME.RegionType.HYPERCUBE
+  REGION_TYPE = ME.RegionType.HYPER_CUBE
 
   # To use the model, must call initialize_coords before forward pass.
   # Once data is processed, call clear to reset the model before calling initialize_coords
@@ -1002,7 +1002,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         stride=1,
         dilation=1,
         has_bias=False,
-        region_type=ME.RegionType.HYPERCUBE,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -1071,7 +1071,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         CHANNELS[4],
         CHANNELS[4],
         bn_momentum=bn_momentum,
-        region_type=ME.RegionType.HYPERCUBE,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
 
     self.conv4_tr = conv_tr(
@@ -1081,7 +1081,7 @@ class ResUNet2SP(ME.MinkowskiNetwork):
         stride=2,
         dilation=1,
         has_bias=False,
-        region_type=ME.RegionType.HYPERCUBE,
+        region_type=ME.RegionType.HYPER_CUBE,
         dimension=D)
     self.norm4_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -1218,4 +1218,4 @@ class ResUNetBN2SPC(ResUNet2SP):
 
 
 class ResUNetBN2SPCX(ResUNetBN2SPC):
-  REGION_TYPE = ME.RegionType.HYPERCROSS
+  REGION_TYPE = ME.RegionType.HYPER_CROSS

--- a/model/simpleunet.py
+++ b/model/simpleunet.py
@@ -35,7 +35,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, D=D)
 
@@ -45,7 +45,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, D=D)
 
@@ -55,7 +55,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, D=D)
 
@@ -65,7 +65,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, D=D)
 
@@ -75,7 +75,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2_tr = get_norm(NORM_TYPE, TR_CHANNELS[2], bn_momentum=bn_momentum, D=D)
 
@@ -85,7 +85,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1_tr = get_norm(NORM_TYPE, TR_CHANNELS[1], bn_momentum=bn_momentum, D=D)
 
@@ -95,7 +95,7 @@ class SimpleNet(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -131,8 +131,8 @@ class SimpleNet(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / torch.norm(out.F, p=2, dim=1, keepdim=True),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -179,7 +179,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -189,7 +189,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
 
@@ -199,7 +199,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
 
@@ -209,7 +209,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4 = get_norm(NORM_TYPE, CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
 
@@ -219,7 +219,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -230,7 +230,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -241,7 +241,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -252,7 +252,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
@@ -263,7 +263,7 @@ class SimpleNet2(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -309,8 +309,8 @@ class SimpleNet2(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / torch.norm(out.F, p=2, dim=1, keepdim=True),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 
@@ -376,7 +376,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=conv1_kernel_size,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm1 = get_norm(NORM_TYPE, CHANNELS[1], bn_momentum=bn_momentum, dimension=D)
 
@@ -386,7 +386,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2 = get_norm(NORM_TYPE, CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
 
@@ -396,7 +396,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3 = get_norm(NORM_TYPE, CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
 
@@ -406,7 +406,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4 = get_norm(NORM_TYPE, CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
 
@@ -416,7 +416,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm5 = get_norm(NORM_TYPE, CHANNELS[5], bn_momentum=bn_momentum, dimension=D)
 
@@ -426,7 +426,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm5_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[5], bn_momentum=bn_momentum, dimension=D)
@@ -437,7 +437,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm4_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[4], bn_momentum=bn_momentum, dimension=D)
@@ -448,7 +448,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm3_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[3], bn_momentum=bn_momentum, dimension=D)
@@ -459,7 +459,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=3,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=D)
     self.norm2_tr = get_norm(
         NORM_TYPE, TR_CHANNELS[2], bn_momentum=bn_momentum, dimension=D)
@@ -470,7 +470,7 @@ class SimpleNet3(ME.MinkowskiNetwork):
         kernel_size=1,
         stride=1,
         dilation=1,
-        has_bias=True,
+        bias=True,
         dimension=D)
 
   def forward(self, x):
@@ -522,8 +522,8 @@ class SimpleNet3(ME.MinkowskiNetwork):
     if self.normalize_feature:
       return ME.SparseTensor(
           out.F / torch.norm(out.F, p=2, dim=1, keepdim=True),
-          coords_key=out.coords_key,
-          coords_manager=out.coords_man)
+          coordinate_map_key=out.coordinate_map_key,
+          coordinate_manager=out.coordinate_manager)
     else:
       return out
 


### PR DESCRIPTION
I tried to get the `demo.py` working on Ubuntu 20.04 (on the WSL2 on Windows11).
When I used the following dependent libraries, `demo.py` stopped working, so I fixed them.

* CUDA: 11.1.1-1
* PyTorch: 1.8.2
* Minkowski Engine: 0.5.4
* Open3D: 0.15.1

**The fix may not be complete.**